### PR TITLE
feat: expand orchestrator run modes

### DIFF
--- a/apps/orchestrator/index.ts
+++ b/apps/orchestrator/index.ts
@@ -1,21 +1,108 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
+import { supabase } from '../../packages/shared/supabase';
 
 const LESSON_PICKER_URL = process.env.LESSON_PICKER_URL!;
+const DISPATCHER_URL = process.env.DISPATCHER_URL!;
+const DATA_AGGREGATOR_URL = process.env.DATA_AGGREGATOR_URL!;
+const CURRICULUM_MODIFIER_URL = process.env.CURRICULUM_MODIFIER_URL!;
+const QA_FORMATTER_URL = process.env.QA_FORMATTER_URL!;
+
+async function callWithRetry(
+  url: string,
+  options: any,
+  runType: string,
+  step: string,
+  retries = 3
+): Promise<boolean> {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      const resp = await fetch(url, options);
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+      await supabase.from('orchestrator_log').insert({
+        run_type: runType,
+        step,
+        success: true,
+        run_at: new Date().toISOString()
+      });
+      return true;
+    } catch (err: any) {
+      if (attempt === retries) {
+        await supabase.from('orchestrator_log').insert({
+          run_type: runType,
+          step,
+          success: false,
+          message: err.message,
+          run_at: new Date().toISOString()
+        });
+        return false;
+      }
+    }
+  }
+  return false;
+}
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const runType = req.query.run_type as string;
+  if (runType !== 'daily' && runType !== 'weekly') {
+    res.status(400).json({ error: 'invalid run_type' });
+    return;
+  }
+
   try {
-    const { student_id } = req.query;
-    console.log('Orchestrator triggered', { student_id });
-    if (student_id) {
-      await fetch(LESSON_PICKER_URL, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ student_id })
-      });
+    if (runType === 'daily') {
+      const { data: students } = await supabase
+        .from('students')
+        .select('id')
+        .eq('active', true);
+
+      for (const student of students ?? []) {
+        const pickerOk = await callWithRetry(
+          LESSON_PICKER_URL,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ student_id: student.id })
+          },
+          runType,
+          `lesson-picker:${student.id}`
+        );
+
+        if (pickerOk) {
+          await callWithRetry(
+            DISPATCHER_URL,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ student_id: student.id })
+            },
+            runType,
+            `dispatcher:${student.id}`
+          );
+        }
+      }
+    } else {
+      await callWithRetry(
+        DATA_AGGREGATOR_URL,
+        { method: 'POST' },
+        runType,
+        'data-aggregator'
+      );
+      await callWithRetry(
+        CURRICULUM_MODIFIER_URL,
+        { method: 'POST' },
+        runType,
+        'curriculum-modifier'
+      );
+      await callWithRetry(
+        QA_FORMATTER_URL,
+        { method: 'POST' },
+        runType,
+        'qa-formatter'
+      );
     }
     res.status(200).json({ status: 'ok' });
-  } catch (err:any) {
+  } catch (err: any) {
     console.error(err);
     res.status(500).json({ error: 'orchestration failed' });
   }

--- a/supabase/migrations/0002_add_orchestrator_log.sql
+++ b/supabase/migrations/0002_add_orchestrator_log.sql
@@ -1,0 +1,11 @@
+-- Orchestrator log table and active flag on students
+create table if not exists orchestrator_log (
+  id uuid primary key,
+  run_type text,
+  step text,
+  success boolean,
+  message text,
+  run_at timestamptz default now()
+);
+
+alter table students add column if not exists active boolean default true;


### PR DESCRIPTION
## Summary
- orchestrator supports `run_type` query for daily and weekly flows
- added retry and logging for orchestration calls
- created migrations for `orchestrator_log` table and student `active` flag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac327c859883309e2b4f7c0a27b418