### PR TITLE
feat: add curriculum schema and QA validation

### DIFF
--- a/apps/qa-formatter/index.ts
+++ b/apps/qa-formatter/index.ts
@@ -1,14 +1,54 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
+import fetch from 'node-fetch';
+import Ajv from 'ajv';
+import schema from '../../docs/curriculum.schema.json';
 import { supabase } from '../../packages/shared/supabase';
 
+const NOTIFICATION_BOT_URL = process.env.NOTIFICATION_BOT_URL!;
+const ajv = new Ajv({ allErrors: true });
+const validate = ajv.compile(schema);
+
+function enforceStyle(curriculum: any) {
+  if (typeof curriculum.notes === 'string') {
+    let notes = curriculum.notes.trim();
+    if (notes) {
+      notes = notes.charAt(0).toUpperCase() + notes.slice(1);
+      if (!notes.endsWith('.')) notes += '.';
+      curriculum.notes = notes;
+    }
+  }
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
-  const { student_id, version } = req.body as { student_id: string; version: number };
+  const { curriculum, qa_user } = req.body as { curriculum: any; qa_user: string };
   try {
-    // TODO: validate curriculum schema
+    if (!validate(curriculum)) {
+      const message = `Curriculum validation failed: ${ajv.errorsText(validate.errors)}`;
+      await fetch(NOTIFICATION_BOT_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text: message })
+      });
+      res.status(400).json({ error: 'invalid curriculum' });
+      return;
+    }
+
+    enforceStyle(curriculum);
+
+    await supabase
+      .from('curricula')
+      .update({
+        notes: curriculum.notes,
+        qa_user,
+        approved_at: new Date().toISOString()
+      })
+      .eq('version', curriculum.version)
+      .eq('student_id', curriculum.student_id);
+
     await supabase
       .from('students')
-      .update({ current_curriculum_version: version })
-      .eq('id', student_id);
+      .update({ current_curriculum_version: curriculum.version })
+      .eq('id', curriculum.student_id);
 
     res.status(200).json({ updated: true });
   } catch (err:any) {

--- a/docs/curriculum.schema.json
+++ b/docs/curriculum.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Curriculum",
+  "type": "object",
+  "required": ["version", "student_id", "lessons", "notes"],
+  "properties": {
+    "version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "student_id": {
+      "type": "string",
+      "format": "uuid"
+    },
+    "notes": {
+      "type": "string"
+    },
+    "lessons": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "units"],
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "units": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+              "type": "object",
+              "required": ["id", "duration_minutes"],
+              "properties": {
+                "id": { "type": "string", "format": "uuid" },
+                "duration_minutes": { "type": "number", "minimum": 1 }
+              },
+              "additionalProperties": false
+            }
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.39.0",
         "@upstash/redis": "^1.22.0",
         "@vercel/node": "^2.10.0",
+        "ajv": "^8.12.0",
         "node-fetch": "^3.3.2",
         "openai": "^4.0.0"
       },
@@ -386,6 +387,22 @@
         "ts-morph": "12.0.0"
       }
     },
+    "node_modules/@vercel/static-config/node_modules/ajv": {
+      "version": "8.6.3",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
+      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -435,15 +452,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.6.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.6.3.tgz",
-      "integrity": "sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==",
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
         "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.2.2"
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1087,6 +1104,22 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fastq": {
       "version": "1.19.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "openai": "^4.0.0",
     "@upstash/redis": "^1.22.0",
     "node-fetch": "^3.3.2",
-    "@vercel/node": "^2.10.0"
+    "@vercel/node": "^2.10.0",
+    "ajv": "^8.12.0"
   },
   "devDependencies": {
     "typescript": "^5.2.2",


### PR DESCRIPTION
## Summary
- add curriculum JSON schema
- validate curriculum against schema in QA formatter
- notify bot on invalid curricula and update students with approval metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad46a9a0d883309ba687cb763fe0f3