### PR TITLE
feat: centralize env configuration

### DIFF
--- a/apps/agent-setup/index.ts
+++ b/apps/agent-setup/index.ts
@@ -1,8 +1,9 @@
 import OpenAI from 'openai';
+import { OPENAI_API_KEY } from '../../packages/shared/config';
 
 // `agents` is a new beta feature and may not be typed yet in the SDK, so we
 // cast the client to `any` when calling it.
-const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const client = new OpenAI({ apiKey: OPENAI_API_KEY });
 const betaClient = client as any;
 
 interface AgentSpec {

--- a/apps/curriculum-modifier/index.ts
+++ b/apps/curriculum-modifier/index.ts
@@ -1,6 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import OpenAI from 'openai';
 import { supabase } from '../../packages/shared/supabase';
+import { OPENAI_API_KEY } from '../../packages/shared/config';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
@@ -26,7 +27,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       `propose a new lesson sequence for the student and return JSON with "lesson_ids" ` +
       `and "notes".\nPerformance Summary:\n${summaryText}\nCandidate Lessons:\n${JSON.stringify(lessons)}`;
 
-    const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+    const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
     const completion = await openai.chat.completions.create({
       model: 'gpt-3.5-turbo',
       messages: [{ role: 'user', content: prompt }]

--- a/apps/lesson-picker/index.ts
+++ b/apps/lesson-picker/index.ts
@@ -2,9 +2,10 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { supabase } from '../../packages/shared/supabase';
 import { Redis } from '@upstash/redis';
 import OpenAI from 'openai';
+import { OPENAI_API_KEY } from '../../packages/shared/config';
 
 const redis = Redis.fromEnv();
-const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { student_id } = req.body as { student_id: string };

--- a/apps/notification-bot/index.ts
+++ b/apps/notification-bot/index.ts
@@ -1,7 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
-
-const SLACK_WEBHOOK_URL = process.env.SLACK_WEBHOOK_URL!;
+import { SLACK_WEBHOOK_URL } from '../../packages/shared/config';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { text } = req.body as { text: string };

--- a/apps/orchestrator/index.ts
+++ b/apps/orchestrator/index.ts
@@ -1,12 +1,13 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import fetch from 'node-fetch';
 import { supabase } from '../../packages/shared/supabase';
-
-const LESSON_PICKER_URL = process.env.LESSON_PICKER_URL!;
-const DISPATCHER_URL = process.env.DISPATCHER_URL!;
-const DATA_AGGREGATOR_URL = process.env.DATA_AGGREGATOR_URL!;
-const CURRICULUM_MODIFIER_URL = process.env.CURRICULUM_MODIFIER_URL!;
-const QA_FORMATTER_URL = process.env.QA_FORMATTER_URL!;
+import {
+  LESSON_PICKER_URL,
+  DISPATCHER_URL,
+  DATA_AGGREGATOR_URL,
+  CURRICULUM_MODIFIER_URL,
+  QA_FORMATTER_URL
+} from '../../packages/shared/config';
 
 async function callWithRetry(
   url: string,

--- a/apps/qa-formatter/index.ts
+++ b/apps/qa-formatter/index.ts
@@ -3,8 +3,7 @@ import fetch from 'node-fetch';
 import Ajv from 'ajv';
 import schema from '../../docs/curriculum.schema.json';
 import { supabase } from '../../packages/shared/supabase';
-
-const NOTIFICATION_BOT_URL = process.env.NOTIFICATION_BOT_URL!;
+import { NOTIFICATION_BOT_URL } from '../../packages/shared/config';
 const ajv = new Ajv({ allErrors: true });
 const validate = ajv.compile(schema);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@vercel/node": "^2.10.0",
         "ajv": "^8.12.0",
         "node-fetch": "^3.3.2",
-        "openai": "^4.0.0"
+        "openai": "^4.0.0",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@types/node": "^20.4.2",
@@ -1945,6 +1946,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,14 +8,15 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",
-    "openai": "^4.0.0",
     "@upstash/redis": "^1.22.0",
-    "node-fetch": "^3.3.2",
     "@vercel/node": "^2.10.0",
-    "ajv": "^8.12.0"
+    "ajv": "^8.12.0",
+    "node-fetch": "^3.3.2",
+    "openai": "^4.0.0",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
-    "@types/node": "^20.4.2"
+    "@types/node": "^20.4.2",
+    "typescript": "^5.2.2"
   }
 }

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod';
+
+const envSchema = z.object({
+  SLACK_WEBHOOK_URL: z.string().url(),
+  OPENAI_API_KEY: z.string().min(1),
+  SUPABASE_URL: z.string().url(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().min(1),
+  NOTIFICATION_BOT_URL: z.string().url(),
+  LESSON_PICKER_URL: z.string().url(),
+  DISPATCHER_URL: z.string().url(),
+  DATA_AGGREGATOR_URL: z.string().url(),
+  CURRICULUM_MODIFIER_URL: z.string().url(),
+  QA_FORMATTER_URL: z.string().url(),
+});
+
+const env = envSchema.safeParse(process.env);
+if (!env.success) {
+  console.error('Invalid or missing environment variables:', env.error.flatten().fieldErrors);
+  throw new Error('Invalid environment variables');
+}
+
+export const {
+  SLACK_WEBHOOK_URL,
+  OPENAI_API_KEY,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  NOTIFICATION_BOT_URL,
+  LESSON_PICKER_URL,
+  DISPATCHER_URL,
+  DATA_AGGREGATOR_URL,
+  CURRICULUM_MODIFIER_URL,
+  QA_FORMATTER_URL,
+} = env.data;

--- a/packages/shared/supabase.ts
+++ b/packages/shared/supabase.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
+import { SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY } from './config';
 
 export const supabase = createClient(
-  process.env.SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
 );


### PR DESCRIPTION
## Summary
- add shared config module with runtime env validation
- replace direct `process.env` usage in agents with config imports
- include `zod` dependency for schema-based validation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ad4b1e3d688330bdba9f7c9c984537