### PR TITLE
feat: add match lessons rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm test
 ## Deployment
 
 - Vercel deploys the functions under `apps/`.
-- Supabase migrations can be executed with the Supabase CLI.
+- Supabase migrations should be applied during deployment using the Supabase CLI, e.g. `supabase db push`.
 - GitHub Actions `daily-run.yml` and `weekly-run.yml` trigger orchestrator endpoints at 07:00 daily and 23:00 Friday respectively.
 
 ## Notes

--- a/docs/match-lessons-rpc.md
+++ b/docs/match-lessons-rpc.md
@@ -1,0 +1,21 @@
+# `match_lessons` RPC
+
+Exposes semantic search over the `lessons` table using the `pgvector` extension.
+
+## Parameters
+
+- `query_embedding vector(1536)` – embedding of the search query
+- `match_threshold float` – minimum similarity score (0-1)
+- `match_count int` – maximum number of lessons to return
+
+## Returns
+
+The function returns each lesson's `id`, `topic`, `difficulty`, `asset_url` and a `similarity` score.
+
+## Example
+
+```sql
+select * from match_lessons('[0, 0, ...]', 0.75, 5);
+```
+
+Use the `similarity` value to filter results or pick the most relevant lessons.

--- a/supabase/migrations/0004_match_lessons.sql
+++ b/supabase/migrations/0004_match_lessons.sql
@@ -1,0 +1,31 @@
+-- Function to match lessons using pgvector similarity
+create or replace function match_lessons(
+  query_embedding vector(1536),
+  match_threshold float,
+  match_count int
+) returns table (
+  id uuid,
+  topic text,
+  difficulty int,
+  asset_url text,
+  similarity float
+) as $$
+  select
+    l.id,
+    l.topic,
+    l.difficulty,
+    l.asset_url,
+    1 - (l.vector_embedding <=> query_embedding) as similarity
+  from lessons l
+  where 1 - (l.vector_embedding <=> query_embedding) > match_threshold
+  order by l.vector_embedding <=> query_embedding
+  limit match_count;
+$$ language sql stable;
+
+-- Index for efficient vector similarity search
+create index if not exists lessons_vector_embedding_idx
+  on lessons using ivfflat (vector_embedding vector_cosine_ops)
+  with (lists = 100);
+
+-- Allow callers to execute the match_lessons function
+grant execute on function match_lessons(vector(1536), float, int) to authenticated, anon, service_role;


### PR DESCRIPTION
## Summary
- add `match_lessons` RPC using pgvector for semantic lesson search
- document RPC and note running migrations during deployment

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad4b3ed1e88330a4756de40e97b916