### PR TITLE
Store curricula as structured JSON with units

### DIFF
--- a/apps/qa-formatter/index.ts
+++ b/apps/qa-formatter/index.ts
@@ -16,6 +16,19 @@ function enforceStyle(curriculum: any) {
       curriculum.notes = notes;
     }
   }
+  if (Array.isArray(curriculum.lessons)) {
+    for (const lesson of curriculum.lessons) {
+      if (Array.isArray(lesson.units)) {
+        lesson.units = lesson.units.map((unit: any) => ({
+          ...unit,
+          duration_minutes: Math.max(
+            1,
+            Math.round(Number(unit.duration_minutes))
+          )
+        }));
+      }
+    }
+  }
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
@@ -42,7 +55,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     await supabase
       .from('curricula')
       .update({
-        notes: curriculum.notes,
+        curriculum,
         qa_user,
         approved_at: new Date().toISOString()
       })

--- a/docs/mas-brief.md
+++ b/docs/mas-brief.md
@@ -40,7 +40,7 @@ All processes are driven by an LLM-based multi-agent system with observability a
 | `students` | `id, name, timezone, current_curriculum_version, last_lesson_sent` | Manage personalization status |
 | `lessons` | `id, topic, difficulty, asset_url, vector_embedding` | Fixed lesson catalog |
 | `performances` | `id, student_id, lesson_id, score, confidence_rating` | Source data for learning results |
-| `curricula` | `version, student_id, lesson_ids[], notes` | Version-controlled learning plan |
+| `curricula` | `version, student_id, curriculum json, qa_user, approved_at` | Version-controlled learning plan |
 | `assignments` | `id, lesson_id, student_id, questions_json, generated_by` | Supplementary problem sets |
 | `dispatch_log` | `id, student_id, lesson_id, sent_at, channel, status` | Operational visibility |
 

--- a/supabase/migrations/0005_curricula_json.sql
+++ b/supabase/migrations/0005_curricula_json.sql
@@ -1,0 +1,30 @@
+-- Migrate curricula table to store structured curriculum JSON
+alter table curricula
+  add column if not exists curriculum jsonb,
+  add column if not exists qa_user text,
+  add column if not exists approved_at timestamptz;
+
+-- Convert existing data if needed
+update curricula
+set curriculum = jsonb_build_object(
+  'version', version,
+  'student_id', student_id,
+  'notes', coalesce(notes, ''),
+  'lessons', (
+    select coalesce(jsonb_agg(
+      jsonb_build_object(
+        'id', lesson_id,
+        'units', jsonb_build_array(
+          jsonb_build_object('id', lesson_id, 'duration_minutes', 1)
+        )
+      )
+    ), '[]'::jsonb)
+    from unnest(coalesce(lesson_ids, '{}'::uuid[])) as lesson_id
+  )
+)
+where curriculum is null;
+
+-- Drop old columns
+alter table curricula
+  drop column if exists lesson_ids,
+  drop column if exists notes;


### PR DESCRIPTION
## Summary
- Generate curricula with nested units and durations and save as JSON
- Validate and style curriculum JSON before approval
- Convert existing curricula data to the new JSON structure

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad4cf9a9c48330ba873896bad98add