### PR TITLE
Use dispatch log IDs to trigger lesson dispatcher

### DIFF
--- a/apps/lesson-picker/index.ts
+++ b/apps/lesson-picker/index.ts
@@ -51,6 +51,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     );
 
     let assignmentId: string | undefined;
+    let dispatchLogId: string | undefined;
     if (lesson && avgScore < 60) {
       const { data: assignment } = await supabase
         .from('assignments')
@@ -66,15 +67,20 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     }
 
     if (lesson) {
-      await supabase.from('dispatch_log').insert({
-        student_id,
-        lesson_id: lesson.id,
-        channel: 'auto',
-        status: 'pending'
-      });
+      const { data: dispatchLog } = await supabase
+        .from('dispatch_log')
+        .insert({
+          student_id,
+          lesson_id: lesson.id,
+          channel: 'auto',
+          status: 'pending'
+        })
+        .select('id')
+        .single();
+      dispatchLogId = dispatchLog?.id;
     }
 
-    res.status(200).json({ lesson_id: lesson?.id, assignment_id: assignmentId });
+    res.status(200).json({ lesson_id: lesson?.id, assignment_id: assignmentId, log_id: dispatchLogId });
   } catch (err:any) {
     console.error(err);
     res.status(500).json({ error: 'lesson selection failed' });

--- a/apps/orchestrator/index.ts
+++ b/apps/orchestrator/index.ts
@@ -37,16 +37,19 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         );
 
         if (pickerResp) {
-          await callWithRetry(
-            DISPATCHER_URL,
-            {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ student_id: student.id })
-            },
-            runType,
-            `dispatcher:${student.id}`
-          );
+          const pickerJson = (await pickerResp.json()) as { log_id?: string };
+          if (pickerJson?.log_id) {
+            await callWithRetry(
+              DISPATCHER_URL,
+              {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ log_id: pickerJson.log_id })
+              },
+              runType,
+              `dispatcher:${student.id}`
+            );
+          }
         }
       }
     } else {


### PR DESCRIPTION
## Summary
- Return created dispatch log ID from lesson picker responses
- Have orchestrator pass dispatch log ID to dispatcher instead of student ID

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad695e50388330af20b9f0ed762e2f