### PR TITLE
Propagate dispatch log IDs through orchestration pipeline

### DIFF
--- a/apps/dispatcher/index.ts
+++ b/apps/dispatcher/index.ts
@@ -2,12 +2,13 @@ import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { supabase } from '../../packages/shared/supabase';
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  // Incoming requests must provide the dispatch log's ID.
   const { log_id } = req.body as { log_id: string };
   try {
     const { data: log } = await supabase
       .from('dispatch_log')
       .select('*')
-      .eq('id', log_id)
+      .eq('id', log_id) // Lookup solely by the provided log_id
       .single();
 
     if (log) {

--- a/apps/lesson-picker/index.ts
+++ b/apps/lesson-picker/index.ts
@@ -65,16 +65,24 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       assignmentId = assignment?.id;
     }
 
+    let logId: string | undefined;
     if (lesson) {
-      await supabase.from('dispatch_log').insert({
-        student_id,
-        lesson_id: lesson.id,
-        channel: 'auto',
-        status: 'pending'
-      });
+      const { data: log } = await supabase
+        .from('dispatch_log')
+        .insert({
+          student_id,
+          lesson_id: lesson.id,
+          channel: 'auto',
+          status: 'pending'
+        })
+        .select('id')
+        .single();
+      logId = log?.id;
     }
 
-    res.status(200).json({ lesson_id: lesson?.id, assignment_id: assignmentId });
+    res
+      .status(200)
+      .json({ lesson_id: lesson?.id, assignment_id: assignmentId, log_id: logId });
   } catch (err:any) {
     console.error(err);
     res.status(500).json({ error: 'lesson selection failed' });

--- a/apps/orchestrator/index.ts
+++ b/apps/orchestrator/index.ts
@@ -37,12 +37,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         );
 
         if (pickerResp) {
+          const pickerData = (await pickerResp.json()) as { log_id?: string };
           await callWithRetry(
             DISPATCHER_URL,
             {
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ student_id: student.id })
+              body: JSON.stringify({ log_id: pickerData.log_id })
             },
             runType,
             `dispatcher:${student.id}`


### PR DESCRIPTION
## Summary
- Capture dispatch_log IDs in lesson picker and include them in responses.
- Pass log_id from lesson picker to dispatcher via orchestrator.
- Dispatcher now relies solely on provided log_id when updating dispatch_log.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad69570e988330b4b4dfb2631dfacd