### PR TITLE
Handle per-student curriculum updates

### DIFF
--- a/apps/curriculum-modifier/index.test.ts
+++ b/apps/curriculum-modifier/index.test.ts
@@ -22,11 +22,25 @@ process.env.QA_FORMATTER_URL = 'http://example.com';
     from: () => ({
       download: async (path: string) => {
         requestedPath = path;
-        return { text: async () => '{}' } as any;
+        return {
+          data: {
+            text: async () =>
+              JSON.stringify({
+                students: [
+                  { student_id: '1', avg: 1 },
+                  { student_id: '2', avg: 2 },
+                ],
+              }),
+          },
+        } as any;
       },
     }),
   } as any;
 
-  await fetchLatestSummary();
+  const summaries = await fetchLatestSummary();
   assert.equal(requestedPath, LATEST_SUMMARY_PATH);
+  assert.equal(Array.isArray(summaries), true);
+  assert.equal(summaries.length, 2);
+  assert.equal(summaries[0].summary.student_id, '1');
+  assert.equal(summaries[1].summary.student_id, '2');
 })();

--- a/apps/curriculum-modifier/index.ts
+++ b/apps/curriculum-modifier/index.ts
@@ -8,80 +8,92 @@ export async function fetchLatestSummary() {
   const { data: file } = await supabase.storage
     .from('summaries')
     .download(LATEST_SUMMARY_PATH);
-  const summaryText = file ? await file.text() : '{}';
-  return { summary: JSON.parse(summaryText), summaryText };
+  const rawText = file ? await file.text() : '{}';
+  let parsed: any = {};
+  try {
+    parsed = JSON.parse(rawText);
+  } catch {
+    parsed = {};
+  }
+  const students: any[] = Array.isArray(parsed.students) ? parsed.students : [];
+  return students.map((s) => ({ summary: s, summaryText: JSON.stringify(s) }));
 }
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
-    // 1. Load performance summary from Supabase storage
-    const { summary, summaryText } = await fetchLatestSummary();
-
-    // derive student id from summary or performances
-    const student_id =
-      summary.student_id || summary.performances?.[0]?.student_id || 'demo';
+    // 1. Load performance summaries from Supabase storage
+    const summaries = await fetchLatestSummary();
 
     // 2. Retrieve candidate lessons from Supabase
     const { data: lessons } = await supabase
       .from('lessons')
       .select('id, topic, difficulty')
       .limit(10);
-
-    // 3. Ask OpenAI to propose a new curriculum structure
-    const prompt =
-      `Given the performance summary and candidate lessons, propose a new curriculum ` +
-      `for the student and return JSON with \"lessons\" (each with units containing id and duration_minutes) ` +
-      `and \"notes\".\nPerformance Summary:\n${summaryText}\nCandidate Lessons:\n${JSON.stringify(lessons)}`;
+    const lessonsText = JSON.stringify(lessons);
 
     const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-3.5-turbo',
-      messages: [{ role: 'user', content: prompt }]
-    });
-    const llmResponse = completion.choices[0]?.message?.content || '{}';
+    const versions: { student_id: string; version: number }[] = [];
 
-    let proposal: any = {};
-    try {
-      proposal = JSON.parse(llmResponse);
-    } catch {
-      proposal = { lessons: [], notes: 'LLM response parsing failed' };
+    for (const { summary, summaryText } of summaries) {
+      const student_id = summary.student_id || 'demo';
+
+      // 3. Ask OpenAI to propose a new curriculum structure
+      const prompt =
+        `Given the performance summary and candidate lessons, propose a new curriculum ` +
+        `for the student and return JSON with \"lessons\" (each with units containing id and duration_minutes) ` +
+        `and \"notes\".\nPerformance Summary:\n${summaryText}\nCandidate Lessons:\n${lessonsText}`;
+
+      const completion = await openai.chat.completions.create({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: prompt }]
+      });
+      const llmResponse = completion.choices[0]?.message?.content || '{}';
+
+      let proposal: any = {};
+      try {
+        proposal = JSON.parse(llmResponse);
+      } catch {
+        proposal = { lessons: [], notes: 'LLM response parsing failed' };
+      }
+
+      // 4. Determine next curriculum version for the student
+      const { data: last } = await supabase
+        .from('curricula')
+        .select('version')
+        .eq('student_id', student_id)
+        .order('version', { ascending: false })
+        .limit(1);
+      const newVersion = last && last.length > 0 ? last[0].version + 1 : 1;
+
+      const curriculum = {
+        version: newVersion,
+        student_id,
+        notes: proposal.notes || '',
+        lessons: proposal.lessons || []
+      };
+
+      await supabase.from('curricula').insert({
+        version: newVersion,
+        student_id,
+        curriculum
+      });
+
+      // 5. Store prompt and response for audit trail
+      const auditContent = Buffer.from(
+        JSON.stringify({ prompt, response: llmResponse }, null, 2)
+      );
+      await supabase.storage
+        .from('summaries')
+        .upload(
+          `curriculum_audit/${student_id}_${newVersion}.json`,
+          auditContent,
+          { upsert: true, contentType: 'application/json' }
+        );
+
+      versions.push({ student_id, version: newVersion });
     }
 
-    // 4. Determine next curriculum version for the student
-    const { data: last } = await supabase
-      .from('curricula')
-      .select('version')
-      .eq('student_id', student_id)
-      .order('version', { ascending: false })
-      .limit(1);
-    const newVersion = last && last.length > 0 ? last[0].version + 1 : 1;
-
-    const curriculum = {
-      version: newVersion,
-      student_id,
-      notes: proposal.notes || '',
-      lessons: proposal.lessons || []
-    };
-
-    await supabase.from('curricula').insert({
-      version: newVersion,
-      student_id,
-      curriculum
-    });
-
-    // 5. Store prompt and response for audit trail
-    const auditContent = Buffer.from(
-      JSON.stringify({ prompt, response: llmResponse }, null, 2)
-    );
-    await supabase.storage
-      .from('summaries')
-      .upload(
-        `curriculum_audit/${student_id}_${newVersion}.json`,
-        auditContent,
-        { upsert: true, contentType: 'application/json' }
-      );
-
-    res.status(200).json({ version: newVersion });
+    res.status(200).json({ versions });
   } catch (err: any) {
     console.error(err);
     res.status(500).json({ error: 'curriculum update failed' });


### PR DESCRIPTION
## Summary
- Modify curriculum modifier to process performance summaries for each student, creating curricula and audit logs per student
- Adjust fetchLatestSummary to return an array of student summaries
- Update tests for new summary format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad69c2b90083308db69ade0e2a1a3f