### PR TITLE
fix: correct supabase import paths

### DIFF
--- a/apps/score-recorder/index.test.ts
+++ b/apps/score-recorder/index.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert';
-import { updateLastScores, LAST_SCORES_TTL } from './index.js';
+import { updateLastScores, LAST_SCORES_TTL } from './index';
 
 class MockRedis {
   public lastExpire: [string, number] | null = null;

--- a/apps/score-recorder/index.ts
+++ b/apps/score-recorder/index.ts
@@ -34,7 +34,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     confidence_rating?: number;
   };
   try {
-    const { supabase } = await import('../../packages/shared/supabase.js');
+    const { supabase } = await import('../../packages/shared/supabase');
     const { data } = await supabase
       .from('performances')
       .insert({ student_id, lesson_id, score, confidence_rating })


### PR DESCRIPTION
## Summary
- import shared supabase module without `.js` extension
- reference the score recorder module consistently in its test

## Testing
- `SLACK_WEBHOOK_URL=http://example.com OPENAI_API_KEY=test SUPABASE_URL=http://example.com SUPABASE_SERVICE_ROLE_KEY=key NOTIFICATION_BOT_URL=http://example.com LESSON_PICKER_URL=http://example.com DISPATCHER_URL=http://example.com DATA_AGGREGATOR_URL=http://example.com CURRICULUM_MODIFIER_URL=http://example.com QA_FORMATTER_URL=http://example.com UPSTASH_REDIS_REST_URL=http://example.com UPSTASH_REDIS_REST_TOKEN=token npm test`
- `SLACK_WEBHOOK_URL=http://example.com OPENAI_API_KEY=test SUPABASE_URL=http://example.com SUPABASE_SERVICE_ROLE_KEY=key NOTIFICATION_BOT_URL=http://example.com LESSON_PICKER_URL=http://example.com DISPATCHER_URL=http://example.com DATA_AGGREGATOR_URL=http://example.com CURRICULUM_MODIFIER_URL=http://example.com QA_FORMATTER_URL=http://example.com UPSTASH_REDIS_REST_URL=http://example.com UPSTASH_REDIS_REST_TOKEN=token npx tsx apps/score-recorder/index.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ad708c17bc8330a6ff9b989c4e4372