### PR TITLE
feat: support generic service logging

### DIFF
--- a/apps/orchestrator/index.ts
+++ b/apps/orchestrator/index.ts
@@ -62,7 +62,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               body: body ? JSON.stringify(body) : undefined
             },
             runType,
-            `${step.label}:${student.id}`
+            `${step.label}:${student.id}`,
+            3,
+            'orchestrator_log'
           );
         }
       }
@@ -78,7 +80,9 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
               : {})
           },
           runType,
-          step.label
+          step.label,
+          3,
+          'orchestrator_log'
         );
       }
     }

--- a/packages/shared/retry.ts
+++ b/packages/shared/retry.ts
@@ -6,13 +6,14 @@ export async function callWithRetry(
   options: any,
   runType: string,
   step: string,
-  retries = 3
+  retries = 3,
+  logTable = 'service_log'
 ): Promise<Response | null> {
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
       const resp = await fetch(url, options);
       if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
-      await supabase.from('orchestrator_log').insert({
+      await supabase.from(logTable).insert({
         run_type: runType,
         step,
         success: true,
@@ -21,7 +22,7 @@ export async function callWithRetry(
       return resp;
     } catch (err: any) {
       if (attempt === retries) {
-        await supabase.from('orchestrator_log').insert({
+        await supabase.from(logTable).insert({
           run_type: runType,
           step,
           success: false,

--- a/supabase/migrations/0006_add_service_log.sql
+++ b/supabase/migrations/0006_add_service_log.sql
@@ -1,0 +1,15 @@
+-- Generic service log table and policies
+create table if not exists service_log (
+  id uuid primary key,
+  run_type text,
+  step text,
+  success boolean,
+  message text,
+  run_at timestamptz default now()
+);
+
+alter table service_log enable row level security;
+
+create policy select_service_log on service_log for select using (true);
+create policy insert_service_log on service_log for insert with check (true);
+create policy update_service_log on service_log for update using (true) with check (true);


### PR DESCRIPTION
## Summary
- add optional `logTable` parameter to `callWithRetry` with default `service_log`
- log orchestrator retries to `orchestrator_log`
- add Supabase migration for shared `service_log` table

## Testing
- `npm test` *(fails: Invalid or missing environment variables: UPSTASH_REDIS_REST_URL, UPSTASH_REDIS_REST_TOKEN)*

------
https://chatgpt.com/codex/tasks/task_e_68ad70f7400c83308b2b538144974815