### PR TITLE
Ensure all app tests run after TypeScript check

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "tsc -p tsconfig.json --noEmit && tsx apps/curriculum-modifier/index.test.ts && tsx apps/qa-formatter/index.test.ts && tsx apps/dispatcher/index.test.ts && tsx apps/orchestrator/index.test.ts"
+    "test": "tsc -p tsconfig.json --noEmit && tsx apps/curriculum-editor/index.test.ts && tsx apps/qa-formatter/index.test.ts && tsx apps/dispatcher/index.test.ts && tsx apps/orchestrator/index.test.ts && tsx apps/performance-recorder/index.test.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",


### PR DESCRIPTION
## Summary
- run curriculum-editor, qa-formatter, dispatcher, orchestrator, and performance-recorder tests
- keep TypeScript compile check before executing tests

## Testing
- `npm test` *(fails: Invalid environment variables: { CURRICULUM_EDITOR_URL: ['Required'] })*


------
https://chatgpt.com/codex/tasks/task_e_68b017aef8d88330b4efb0199f518484