### PR TITLE
Add orchestrator auth header validation

### DIFF
--- a/apps/orchestrator/index.ts
+++ b/apps/orchestrator/index.ts
@@ -36,6 +36,13 @@ const WEEKLY_STEPS: StepDescriptor<void>[] = [
 ];
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const authHeader = req.headers['authorization'];
+  const expected = `Bearer ${process.env.ORCHESTRATOR_SECRET}`;
+  if (!authHeader || authHeader !== expected) {
+    res.status(401).json({ error: 'unauthorized' });
+    return;
+  }
+
   const runType = req.query.run_type as string;
   if (runType !== 'daily' && runType !== 'weekly') {
     res.status(400).json({ error: 'invalid run_type' });


### PR DESCRIPTION
## Summary
- require `Authorization` header matching `Bearer ${ORCHESTRATOR_SECRET}` for orchestrator endpoint
- return 401 on missing or invalid tokens
- test authorized and unauthorized orchestrator requests

## Testing
- `npm test` *(fails: Invalid environment variables)*
- `npx tsx apps/orchestrator/index.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b12319740c833090718f3b9c5e86bc