### PR TITLE
Filter dispatches by status and test completion rates

### DIFF
--- a/apps/data-aggregator/index.test.ts
+++ b/apps/data-aggregator/index.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+
+// Set env variables before importing modules
+process.env.SLACK_WEBHOOK_URL = 'http://example.com';
+process.env.OPENAI_API_KEY = 'test';
+process.env.SUPABASE_URL = 'http://example.com';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+process.env.NOTIFICATION_BOT_URL = 'http://example.com';
+process.env.LESSON_PICKER_URL = 'http://example.com';
+process.env.DISPATCHER_URL = 'http://example.com';
+process.env.DATA_AGGREGATOR_URL = 'http://example.com';
+process.env.CURRICULUM_EDITOR_URL = 'http://example.com';
+process.env.QA_FORMATTER_URL = 'http://example.com';
+process.env.UPSTASH_REDIS_REST_URL = 'http://example.com';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+
+(async () => {
+  const { aggregateStudentStats } = await import('./index');
+
+  const performances = [
+    { student_id: 's1', score: 80, confidence_rating: 4, timestamp: '2024-01-01' },
+  ];
+  const dispatches = [
+    { student_id: 's1', status: 'sent' },
+    { student_id: 's1', status: 'failed' },
+    { student_id: 's2', status: 'sent' },
+    { student_id: 's2', status: 'failed' },
+  ];
+
+  const students = await aggregateStudentStats(
+    performances,
+    dispatches,
+    'ts',
+    async () => 'chart-url'
+  );
+
+  const s1 = students.find((s) => s.student_id === 's1');
+  const s2 = students.find((s) => s.student_id === 's2');
+  assert.equal(s1?.completion_rate, 1);
+  assert.equal(s2?.completion_rate, 0);
+  console.log('Accurate completion rates with mixed dispatch statuses');
+})();

--- a/apps/performance-recorder/index.test.ts
+++ b/apps/performance-recorder/index.test.ts
@@ -1,5 +1,18 @@
 import assert from 'assert';
-import { updateLastScores, LAST_SCORES_TTL } from './index';
+
+// Set env variables before importing modules
+process.env.SLACK_WEBHOOK_URL = 'http://example.com';
+process.env.OPENAI_API_KEY = 'test';
+process.env.SUPABASE_URL = 'http://example.com';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+process.env.NOTIFICATION_BOT_URL = 'http://example.com';
+process.env.LESSON_PICKER_URL = 'http://example.com';
+process.env.DISPATCHER_URL = 'http://example.com';
+process.env.DATA_AGGREGATOR_URL = 'http://example.com';
+process.env.CURRICULUM_EDITOR_URL = 'http://example.com';
+process.env.QA_FORMATTER_URL = 'http://example.com';
+process.env.UPSTASH_REDIS_REST_URL = 'http://example.com';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
 
 class MockRedis {
   public lastExpire: [string, number] | null = null;
@@ -11,6 +24,7 @@ class MockRedis {
 }
 
 (async () => {
+  const { updateLastScores, LAST_SCORES_TTL } = await import('./index');
   const redis = new MockRedis();
   await updateLastScores('student', 1, redis as any);
   assert.deepStrictEqual(redis.lastExpire, [`last_3_scores:student`, LAST_SCORES_TTL]);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "tsc -p tsconfig.json --noEmit && tsx apps/curriculum-editor/index.test.ts && tsx apps/qa-formatter/index.test.ts && tsx apps/dispatcher/index.test.ts && tsx apps/orchestrator/index.test.ts && tsx apps/performance-recorder/index.test.ts"
+    "test": "tsc -p tsconfig.json --noEmit && tsx apps/curriculum-editor/index.test.ts && tsx apps/qa-formatter/index.test.ts && tsx apps/dispatcher/index.test.ts && tsx apps/orchestrator/index.test.ts && tsx apps/performance-recorder/index.test.ts && tsx apps/data-aggregator/index.test.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",


### PR DESCRIPTION
## Summary
- Filter dispatch_log queries to only "sent" records and compute assignments from successful dispatches
- Add helper to aggregate student stats and recalc completion rates
- Add tests covering mixed-status dispatch logs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1233c93088330a5784958b075be53