### PR TITLE
Add last_lesson_id to students schema and policies

### DIFF
--- a/apps/lesson-picker/index.ts
+++ b/apps/lesson-picker/index.ts
@@ -47,7 +47,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       .from('dispatch_log')
       .select('lesson_id')
       .eq('student_id', student_id);
-    const dispatchedIds = previous?.map((d: any) => d.lesson_id) ?? [];
+    const dispatchedIds = [
+      ...(previous?.map((d: any) => d.lesson_id) ?? []),
+      (student as any)?.last_lesson_id
+    ].filter(Boolean);
 
     const avgScore =
       recentScores.length > 0

--- a/docs/db-policies.md
+++ b/docs/db-policies.md
@@ -9,4 +9,4 @@ The database uses row level security (RLS) on all tables. Select access is allow
 
 Foreign key relations use `ON DELETE RESTRICT` to prevent accidental cascades. Triggers on the append-only tables raise exceptions if an update or delete is attempted.
 
-The `students` table stores core profile data (`id`, `name`, `timezone`, `current_curriculum_version`, `last_lesson_sent`) and user preferences. The new `preferred_topics` **text[]** column records any topics a student wants to focus on and informs the lesson picker while remaining mutable under RLS.
+The `students` table stores core profile data (`id`, `name`, `timezone`, `current_curriculum_version`, `last_lesson_sent`, `last_lesson_id`) and user preferences. The `last_lesson_sent` timestamp and `last_lesson_id` UUID track the most recent lesson delivered. The `preferred_topics` **text[]** column records any topics a student wants to focus on and informs the lesson picker while remaining mutable under RLS.

--- a/docs/mas-brief.md
+++ b/docs/mas-brief.md
@@ -37,7 +37,7 @@ All processes are driven by an LLM-based multi-agent system with observability a
 
 | Table | Key Fields | Purpose |
 |-------|------------|---------|
-| `students` | `id, name, timezone, current_curriculum_version, last_lesson_sent, preferred_topics` | Manage personalization status |
+| `students` | `id, name, timezone, current_curriculum_version, last_lesson_sent, last_lesson_id, preferred_topics` | Manage personalization status |
 | `lessons` | `id, topic, difficulty, asset_url, vector_embedding` | Fixed lesson catalog |
 | `performances` | `id, student_id, lesson_id, score, confidence_rating` | Source data for learning results |
 | `curricula` | `version, student_id, curriculum json, qa_user, approved_at` | Version-controlled learning plan |

--- a/supabase/migrations/0010_add_last_lesson_id_to_students.sql
+++ b/supabase/migrations/0010_add_last_lesson_id_to_students.sql
@@ -1,0 +1,27 @@
+-- Add last_lesson_id to students and permit updates
+alter table students add column last_lesson_id uuid;
+
+-- Allow updates to last_lesson_id and last_lesson_sent along with existing fields
+create or replace function restrict_student_updates()
+returns trigger as $$
+begin
+  if (row_to_json(NEW)::jsonb
+        - 'current_curriculum_version'
+        - 'active'
+        - 'last_lesson_sent'
+        - 'last_lesson_id'
+     ) is distinct from (row_to_json(OLD)::jsonb
+        - 'current_curriculum_version'
+        - 'active'
+        - 'last_lesson_sent'
+        - 'last_lesson_id') then
+    raise exception 'Only current_curriculum_version, active, last_lesson_sent, and last_lesson_id can be updated';
+  end if;
+  return NEW;
+end;
+$$ language plpgsql;
+
+drop trigger if exists restrict_student_updates on students;
+create trigger restrict_student_updates
+before update on students
+for each row execute function restrict_student_updates();


### PR DESCRIPTION
## Summary
- add `last_lesson_id` column to `students` table and update RLS trigger to permit updates
- consider `last_lesson_id` during lesson selection to avoid repeats
- document `last_lesson_id` in schema and policy docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b52df3a8908330b7a806c16f4b9e6a