### PR TITLE
Preserve append-only curricula

### DIFF
--- a/apps/orchestrator/index.test.ts
+++ b/apps/orchestrator/index.test.ts
@@ -13,11 +13,13 @@ process.env.ORCHESTRATOR_SECRET = 'secret';
 (async () => {
   // start mock server
   let dispatcherBody: any = null;
+  let lessonPickerBody: any = null;
   const server = http.createServer((req, res) => {
     let body = '';
     req.on('data', (chunk) => (body += chunk));
     req.on('end', () => {
       if (req.url === '/lesson-picker') {
+        lessonPickerBody = body ? JSON.parse(body) : null;
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end(
           JSON.stringify({ lesson_id: 'l1', assignment_id: 'a1', log_id: 'log1' })
@@ -50,7 +52,7 @@ process.env.ORCHESTRATOR_SECRET = 'secret';
   (supabase as any).from = (table: string) => {
     if (table === 'students') {
       return {
-        select: () => ({ eq: () => ({ data: [{ id: 1 }] }) })
+        select: () => ({ eq: () => ({ data: [{ id: 1, current_curriculum_version: 2 }] }) })
       };
     }
     return {
@@ -86,6 +88,7 @@ process.env.ORCHESTRATOR_SECRET = 'secret';
   server.close();
 
   assert.equal(dispatcherBody.log_id, 'log1');
+  assert.equal(lessonPickerBody.curriculum_version, 2);
   console.log('Orchestrator authorization tests passed');
 })();
 

--- a/apps/orchestrator/index.ts
+++ b/apps/orchestrator/index.ts
@@ -16,11 +16,17 @@ type StepDescriptor<T, C = any> = {
   buildBody: (arg: T, context?: C) => any;
 };
 
-const DAILY_STEPS: StepDescriptor<{ id: number }, any>[] = [
+const DAILY_STEPS: StepDescriptor<
+  { id: number; current_curriculum_version: number },
+  any
+>[] = [
   {
     url: LESSON_PICKER_URL,
     label: 'lesson-picker',
-    buildBody: (student) => ({ student_id: student.id })
+    buildBody: (student) => ({
+      student_id: student.id,
+      curriculum_version: student.current_curriculum_version
+    })
   },
   {
     url: DISPATCHER_URL,
@@ -53,7 +59,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
     if (runType === 'daily') {
       const { data: students } = await supabase
         .from('students')
-        .select('id')
+        .select('id, current_curriculum_version')
         .eq('active', true);
 
       for (const student of students ?? []) {

--- a/apps/qa-formatter/index.test.ts
+++ b/apps/qa-formatter/index.test.ts
@@ -18,7 +18,7 @@ process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
   // Stub network and database interactions used by notify
   const supabaseModule = await import('../../packages/shared/supabase');
   const supabase = supabaseModule.supabase as any;
-  supabase.from = () => ({ insert: async () => ({}) });
+  supabase.from = () => ({ insert: async () => ({}), update: async () => ({}) });
 
   const handler = (await import('./index')).default;
 

--- a/apps/qa-formatter/index.ts
+++ b/apps/qa-formatter/index.ts
@@ -63,15 +63,13 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return;
     }
 
-    await supabase
-      .from('curricula')
-      .update({
-        curriculum,
-        qa_user,
-        approved_at: new Date().toISOString()
-      })
-      .eq('version', curriculum.version)
-      .eq('student_id', curriculum.student_id);
+    await supabase.from('curricula').insert({
+      version: curriculum.version,
+      student_id: curriculum.student_id,
+      curriculum,
+      qa_user,
+      approved_at: new Date().toISOString()
+    });
 
     await supabase
       .from('students')

--- a/docs/db-policies.md
+++ b/docs/db-policies.md
@@ -6,6 +6,7 @@ The database uses row level security (RLS) on all tables. Select access is allow
 - **performances** – insert only, no updates or deletes.
 - **assignments** – insert only, no updates or deletes.
 - **curricula** – versioned history, insert only.
+ - **curricula_drafts** – mutable staging table for proposed curricula.
 
 Foreign key relations use `ON DELETE RESTRICT` to prevent accidental cascades. Triggers on the append-only tables raise exceptions if an update or delete is attempted.
 

--- a/docs/mas-brief.md
+++ b/docs/mas-brief.md
@@ -40,7 +40,8 @@ All processes are driven by an LLM-based multi-agent system with observability a
 | `students` | `id, name, timezone, current_curriculum_version, last_lesson_sent, preferred_topics` | Manage personalization status |
 | `lessons` | `id, topic, difficulty, asset_url, vector_embedding` | Fixed lesson catalog |
 | `performances` | `id, student_id, lesson_id, score, confidence_rating` | Source data for learning results |
-| `curricula` | `version, student_id, curriculum json, qa_user, approved_at` | Version-controlled learning plan |
+| `curricula_drafts` | `version, student_id, curriculum json` | Proposed curricula awaiting QA |
+| `curricula` | `version, student_id, curriculum json, qa_user, approved_at` | Approved, version-controlled learning plan |
 | `assignments` | `id, lesson_id, student_id, questions_json, generated_by` | Supplementary problem sets |
 | `dispatch_log` | `id, student_id, lesson_id, sent_at, channel, status` | Operational visibility |
 
@@ -65,8 +66,8 @@ Accuracy priority: External evidence > Long-term > Short-term > Working.
 | Dispatcher | `students`, `lessons`, `dispatch_log` | `dispatch_log(status)` |
 | Performance Recorder | – | `performances` |
 | Data Aggregator | `performances`, charts 📊 | Supabase Storage `performance_summary.json` |
-| Curriculum Editor | `performance_summary`, `lessons` | New `curricula` |
-| QA & Formatter | New `curricula` | `students.current_curriculum_version` |
+| Curriculum Editor | `performance_summary`, `lessons` | `curricula_drafts` |
+| QA & Formatter | `curricula_drafts` | `curricula`, `students.current_curriculum_version` |
 | Notification Bot | Event stream | Slack |
 
 ## 6. Infrastructure Stack (Blueprint 1)

--- a/supabase/migrations/0010_curricula_drafts.sql
+++ b/supabase/migrations/0010_curricula_drafts.sql
@@ -1,0 +1,20 @@
+-- Create table for curriculum drafts to preserve append-only curricula history
+create table if not exists curricula_drafts (
+  student_id uuid not null references students(id) on delete restrict,
+  version int not null,
+  curriculum jsonb not null,
+  created_at timestamptz default now(),
+  primary key (student_id, version)
+);
+
+alter table curricula_drafts enable row level security;
+
+create policy select_curricula_drafts on curricula_drafts for select using (true);
+create policy insert_curricula_drafts on curricula_drafts for insert with check (true);
+create policy update_curricula_drafts on curricula_drafts for update using (true) with check (true);
+create policy delete_curricula_drafts on curricula_drafts for delete using (true);
+
+-- Ensure curricula table stays append-only
+-- Explicitly deny updates and deletes through RLS even for privileged roles
+create policy update_curricula_denied on curricula for update using (false) with check (false);
+create policy delete_curricula_denied on curricula for delete using (false);


### PR DESCRIPTION
## Summary
- Store curriculum drafts separately and insert QA-approved curricula as new rows
- Enforce append-only policies for curricula with Supabase RLS and migrations
- Pass current curriculum version to lesson picker via orchestrator

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b52e3a1e788330bbef54a29a783760