### PR TITLE
Implement exponential backoff and throw on retry failure

### DIFF
--- a/apps/data-aggregator/chartGenerator.ts
+++ b/apps/data-aggregator/chartGenerator.ts
@@ -43,7 +43,6 @@ export async function generatePerformanceChart(
     'data-aggregator',
     'chart-generation'
   );
-  if (!response) throw new Error('chart fetch failed');
   const arrayBuffer = await response.arrayBuffer();
   const buffer = Buffer.from(arrayBuffer);
 

--- a/apps/orchestrator/index.ts
+++ b/apps/orchestrator/index.ts
@@ -57,16 +57,11 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         .eq('active', true);
 
       for (const student of students ?? []) {
-        let lastResp: any = true;
         let context: any = undefined;
         for (const step of DAILY_STEPS) {
-          if (!lastResp) break;
           const body = step.buildBody(student, context);
-          if (!body) {
-            lastResp = null;
-            break;
-          }
-          lastResp = await callWithRetry(
+          if (!body) break;
+          const resp = await callWithRetry(
             step.url,
             {
               method: 'POST',
@@ -78,12 +73,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
             3,
             'orchestrator_log'
           );
-          if (lastResp) {
-            try {
-              context = await lastResp.json();
-            } catch {
-              context = undefined;
-            }
+          try {
+            context = await resp.json();
+          } catch {
+            context = undefined;
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "tsc -p tsconfig.json --noEmit && tsx apps/curriculum-editor/index.test.ts && tsx apps/qa-formatter/index.test.ts && tsx apps/dispatcher/index.test.ts && tsx apps/orchestrator/index.test.ts && tsx apps/performance-recorder/index.test.ts && tsx apps/data-aggregator/index.test.ts"
+    "test": "tsc -p tsconfig.json --noEmit && tsx packages/shared/retry.test.ts && tsx apps/curriculum-editor/index.test.ts && tsx apps/qa-formatter/index.test.ts && tsx apps/dispatcher/index.test.ts && tsx apps/orchestrator/index.test.ts && tsx apps/performance-recorder/index.test.ts && tsx apps/data-aggregator/index.test.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",

--- a/packages/shared/retry.test.ts
+++ b/packages/shared/retry.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+process.env.SLACK_WEBHOOK_URL = 'http://localhost';
+process.env.OPENAI_API_KEY = 'test';
+process.env.NOTIFICATION_BOT_URL = 'http://localhost';
+process.env.LESSON_PICKER_URL = 'http://localhost';
+process.env.DISPATCHER_URL = 'http://localhost';
+process.env.DATA_AGGREGATOR_URL = 'http://localhost';
+process.env.CURRICULUM_EDITOR_URL = 'http://localhost';
+process.env.QA_FORMATTER_URL = 'http://localhost';
+process.env.UPSTASH_REDIS_REST_URL = 'http://localhost';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+
+(async () => {
+  const server = http.createServer((_req, res) => {
+    res.statusCode = 500;
+    res.end('fail');
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const port = (server.address() as any).port;
+  const url = `http://localhost:${port}`;
+
+  const { supabase } = await import('./supabase');
+  (supabase as any).from = () => ({ insert: async () => ({}) });
+
+  const { callWithRetry, BASE_DELAY_MS } = await import('./retry');
+
+  const start = Date.now();
+  let threw = false;
+  try {
+    await callWithRetry(url, {}, 'test', 'step', 2);
+  } catch {
+    threw = true;
+  }
+  const elapsed = Date.now() - start;
+  server.close();
+
+  assert.equal(threw, true);
+  assert(elapsed >= BASE_DELAY_MS);
+  console.log('callWithRetry throws after retries with backoff');
+})();
+

--- a/packages/shared/retry.ts
+++ b/packages/shared/retry.ts
@@ -1,14 +1,17 @@
 import fetch, { Response } from 'node-fetch';
 import { supabase } from './supabase';
 
+export const BASE_DELAY_MS = 200;
+
 export async function callWithRetry(
   url: string,
   options: any,
   runType: string,
   step: string,
   retries = 3,
-  logTable = 'service_log'
-): Promise<Response | null> {
+  logTable = 'service_log',
+): Promise<Response> {
+  let lastError: any;
   for (let attempt = 1; attempt <= retries; attempt++) {
     try {
       const resp = await fetch(url, options);
@@ -21,6 +24,7 @@ export async function callWithRetry(
       });
       return resp;
     } catch (err: any) {
+      lastError = err;
       if (attempt === retries) {
         await supabase.from(logTable).insert({
           run_type: runType,
@@ -29,10 +33,12 @@ export async function callWithRetry(
           message: err.message,
           run_at: new Date().toISOString(),
         });
-        return null;
+        throw err;
       }
+      const delay = BASE_DELAY_MS * Math.pow(2, attempt - 1);
+      await new Promise((resolve) => setTimeout(resolve, delay));
     }
   }
-  return null;
+  throw lastError;
 }
 


### PR DESCRIPTION
## Summary
- add exponential backoff and throw final errors in `callWithRetry`
- simplify orchestrator and chart generator to use new retry semantics
- cover retry failures with a new unit test

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b52eb2f7a88330967336643464f1fa