### PR TITLE
Dispatch units by minute quota and log details

### DIFF
--- a/apps/dispatcher/index.ts
+++ b/apps/dispatcher/index.ts
@@ -1,67 +1,89 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { supabase } from '../../packages/shared/supabase';
 
-export default async function handler(req: VercelRequest, res: VercelResponse) {
-  const { log_id } = req.body as { log_id: string };
-  try {
-    const { data: log } = await supabase
-      .from('dispatch_log')
-      .select('*')
-      .eq('id', log_id)
-      .single();
+async function selectUnits(curriculum: any, minutes: number) {
+  const units: any[] = [];
+  let total = 0;
+  for (const lesson of curriculum.lessons ?? []) {
+    for (const unit of lesson.units ?? []) {
+      if (total >= minutes) break;
+      units.push(unit);
+      total += Number(unit.duration_minutes) || 0;
+    }
+    if (total >= minutes) break;
+  }
+  return { units, total };
+}
 
-    if (log) {
-      const { data: lesson } = await supabase
-        .from('lessons')
-        .select('*')
-        .eq('id', log.lesson_id)
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const { student_id, minutes = 0, units: presetUnits } = req.body as {
+    student_id: string;
+    minutes?: number;
+    units?: any[];
+  };
+
+  try {
+    let selected = { units: presetUnits ?? [], total: 0 };
+
+    if (!presetUnits) {
+      const { data: student } = await supabase
+        .from('students')
+        .select('current_curriculum_version')
+        .eq('id', student_id)
         .single();
 
-      if (lesson) {
-        const response = await fetch(
-          `${process.env.SUPERFASTSAT_API_URL}/lessons`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ lesson })
-          }
-        );
+      if (!student) throw new Error('student not found');
 
-        if (response.ok) {
-          await supabase
-            .from('dispatch_log')
-            .update({ status: 'sent', sent_at: new Date().toISOString() })
-            .eq('id', log_id);
-          await supabase
-            .from('students')
-            .update({
-              last_lesson_sent: new Date().toISOString(),
-              last_lesson_id: log.lesson_id
-            })
-            .eq('id', log.student_id);
-          res.status(200).json({ status: 'dispatched' });
-          return;
-        } else {
-          await supabase
-            .from('dispatch_log')
-            .update({ status: 'failed' })
-            .eq('id', log_id);
-          throw new Error(`SuperfastSAT API responded ${response.status}`);
-        }
-      }
+      const { data: curr } = await supabase
+        .from('curricula')
+        .select('curriculum')
+        .eq('student_id', student_id)
+        .eq('version', student.current_curriculum_version)
+        .single();
+
+      if (!curr) throw new Error('curriculum not found');
+
+      selected = await selectUnits(curr.curriculum, minutes);
+    } else {
+      selected.total = presetUnits.reduce(
+        (sum, u: any) => sum + (Number(u.duration_minutes) || 0),
+        0
+      );
     }
 
-    await supabase
+    const response = await fetch(`${process.env.SUPERFASTSAT_API_URL}/units`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ units: selected.units }),
+    });
+
+    const status = response.ok ? 'sent' : 'failed';
+    const log = await supabase
       .from('dispatch_log')
-      .update({ status: 'failed' })
-      .eq('id', log_id);
-    throw new Error('dispatch data missing');
-  } catch (err:any) {
+      .insert({
+        student_id,
+        unit_ids: selected.units.map((u: any) => u.id),
+        minutes: selected.total,
+        channel: 'auto',
+        status,
+        ...(response.ok ? { sent_at: new Date().toISOString() } : {}),
+      })
+      .select('id')
+      .single();
+
+    await supabase
+      .from('students')
+      .update({ last_lesson_sent: new Date().toISOString() })
+      .eq('id', student_id);
+
+    if (!response.ok) {
+      throw new Error(`SuperfastSAT API responded ${response.status}`);
+    }
+
+    res.status(200).json({ log_id: log.data?.id });
+  } catch (err: any) {
     console.error(err);
-    await supabase
-      .from('dispatch_log')
-      .update({ status: 'failed' })
-      .eq('id', log_id);
     res.status(500).json({ error: 'dispatch failed' });
   }
 }
+

--- a/apps/lesson-picker/index.ts
+++ b/apps/lesson-picker/index.ts
@@ -1,9 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
-import { supabase } from '../../packages/shared/supabase';
 import { Redis } from '@upstash/redis';
-import OpenAI from 'openai';
 import {
-  OPENAI_API_KEY,
   UPSTASH_REDIS_REST_URL,
   UPSTASH_REDIS_REST_TOKEN,
 } from '../../packages/shared/config';
@@ -12,91 +9,24 @@ const redis = new Redis({
   url: UPSTASH_REDIS_REST_URL,
   token: UPSTASH_REDIS_REST_TOKEN,
 });
-const openai = new OpenAI({ apiKey: OPENAI_API_KEY });
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { student_id } = req.body as { student_id: string };
   try {
-    const { data: student } = await supabase
-      .from('students')
-      .select('*')
-      .eq('id', student_id)
-      .single();
-
     const recentScores = await redis.lrange(`last_3_scores:${student_id}`, 0, 2);
-
-    console.log('Lesson picker', { student, recentScores });
-
-    const topics: string[] = Array.isArray((student as any)?.preferred_topics)
-      ? (student as any).preferred_topics
-      : [];
-    const queryText = `Preferred topics: ${topics.join(', ')}. Recent scores: ${recentScores.join(', ')}`;
-    const embeddingResponse = await openai.embeddings.create({
-      model: 'text-embedding-3-small',
-      input: queryText
-    });
-    const queryEmbedding = embeddingResponse.data[0].embedding;
-
-    const { data: matches } = await supabase.rpc('match_lessons', {
-      query_embedding: queryEmbedding,
-      match_threshold: 0.75,
-      match_count: 5
-    });
-
-    const { data: previous } = await supabase
-      .from('dispatch_log')
-      .select('lesson_id')
-      .eq('student_id', student_id);
-    const dispatchedIds = [
-      ...(previous?.map((d: any) => d.lesson_id) ?? []),
-      (student as any)?.last_lesson_id
-    ].filter(Boolean);
 
     const avgScore =
       recentScores.length > 0
         ? recentScores.map(Number).reduce((a, b) => a + b, 0) / recentScores.length
         : 0;
-    const maxDifficulty = Math.max(1, Math.round(avgScore / 20));
 
-    const lesson = matches?.find(
-      (m: any) => m.difficulty <= maxDifficulty && !dispatchedIds.includes(m.id)
-    );
+    // Simple rule: struggling students get more practice time
+    const minutes = avgScore < 60 ? 30 : 15;
 
-    let assignmentId: string | undefined;
-    if (lesson && avgScore < 60) {
-      const { data: assignment } = await supabase
-        .from('assignments')
-        .insert({
-          lesson_id: lesson.id,
-          student_id,
-          questions_json: {},
-          generated_by: 'lesson-picker'
-        })
-        .select('id')
-        .single();
-      assignmentId = assignment?.id;
-    }
-
-    let logId: string | undefined;
-    if (lesson) {
-      const { data: log } = await supabase
-        .from('dispatch_log')
-        .insert({
-          student_id,
-          lesson_id: lesson.id,
-          channel: 'auto',
-          status: 'pending'
-        })
-        .select('id')
-        .single();
-      logId = log?.id;
-    }
-
-    res
-      .status(200)
-      .json({ lesson_id: lesson?.id, assignment_id: assignmentId, log_id: logId });
-  } catch (err:any) {
+    res.status(200).json({ minutes });
+  } catch (err: any) {
     console.error(err);
-    res.status(500).json({ error: 'lesson selection failed' });
+    res.status(500).json({ error: 'minute selection failed' });
   }
 }
+

--- a/apps/orchestrator/index.test.ts
+++ b/apps/orchestrator/index.test.ts
@@ -21,9 +21,7 @@ process.env.ORCHESTRATOR_SECRET = 'secret';
       if (req.url === '/lesson-picker') {
         lessonPickerBody = body ? JSON.parse(body) : null;
         res.writeHead(200, { 'Content-Type': 'application/json' });
-        res.end(
-          JSON.stringify({ lesson_id: 'l1', assignment_id: 'a1', log_id: 'log1' })
-        );
+        res.end(JSON.stringify({ minutes: 5 }));
       } else if (req.url === '/dispatcher') {
         dispatcherBody = body ? JSON.parse(body) : null;
         res.writeHead(200, { 'Content-Type': 'application/json' });
@@ -100,7 +98,8 @@ process.env.ORCHESTRATOR_SECRET = 'secret';
   await handler(req, res);
   server.close();
 
-  assert.equal(dispatcherBody.log_id, 'log1');
+  assert.equal(dispatcherBody.student_id, 1);
+  assert.equal(dispatcherBody.minutes, 5);
   assert.equal(lessonPickerBody.curriculum_version, 2);
   console.log('Orchestrator authorization tests passed');
 })();

--- a/apps/orchestrator/index.ts
+++ b/apps/orchestrator/index.ts
@@ -32,7 +32,12 @@ const DAILY_STEPS: StepDescriptor<
   {
     url: DISPATCHER_URL,
     label: 'dispatcher',
-    buildBody: (_student, ctx) => (ctx?.log_id ? { log_id: ctx.log_id } : undefined)
+    buildBody: (student, ctx) =>
+      ctx?.units
+        ? { student_id: student.id, units: ctx.units }
+        : ctx?.minutes
+        ? { student_id: student.id, minutes: ctx.minutes }
+        : undefined
   }
 ];
 

--- a/supabase/migrations/0011_add_unit_minutes_to_dispatch_log.sql
+++ b/supabase/migrations/0011_add_unit_minutes_to_dispatch_log.sql
@@ -1,0 +1,5 @@
+-- Add unit tracking to dispatch_log
+alter table dispatch_log
+  add column if not exists unit_ids uuid[],
+  add column if not exists minutes int;
+


### PR DESCRIPTION
## Summary
- Replace lesson picker output with minute quota to assign more or less practice
- Dispatcher slices curriculum units to meet requested minutes and logs dispatched units
- Orchestrator forwards lesson-picker minutes to dispatcher

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5332a30e483309a7e863f0cb06a8a