### PR TITLE
Handle Slack failures in notification bot

### DIFF
--- a/apps/notification-bot/index.test.ts
+++ b/apps/notification-bot/index.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import http from 'node:http';
+
+// Provide required env variables before importing modules
+process.env.OPENAI_API_KEY = 'test';
+process.env.SUPABASE_URL = 'http://example.com';
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+process.env.NOTIFICATION_BOT_URL = 'http://example.com';
+process.env.LESSON_PICKER_URL = 'http://example.com';
+process.env.DISPATCHER_URL = 'http://example.com';
+process.env.DATA_AGGREGATOR_URL = 'http://example.com';
+process.env.CURRICULUM_EDITOR_URL = 'http://example.com';
+process.env.QA_FORMATTER_URL = 'http://example.com';
+process.env.UPSTASH_REDIS_REST_URL = 'http://example.com';
+process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+
+(async () => {
+  let nextStatus = 500;
+  const server = http.createServer((_req, res) => {
+    res.writeHead(nextStatus, { 'Content-Type': 'application/json' });
+    res.end('{}');
+  });
+  await new Promise<void>((resolve) => server.listen(0, resolve));
+  const port = (server.address() as any).port;
+  process.env.SLACK_WEBHOOK_URL = `http://localhost:${port}/slack`;
+
+  const supabaseModule = await import('../../packages/shared/supabase');
+  const supabase = supabaseModule.supabase as any;
+  supabase.from = () => ({ insert: async () => ({}) });
+
+  const handler = (await import('./index')).default;
+
+  function createRes() {
+    return {
+      statusCode: 0,
+      body: undefined as any,
+      status(code: number) {
+        this.statusCode = code;
+        return this;
+      },
+      json(payload: any) {
+        this.body = payload;
+      },
+    };
+  }
+
+  // failure path
+  nextStatus = 500;
+  const resFail = createRes();
+  await handler({ body: { text: 'hi' } } as any, resFail as any);
+  assert.equal(resFail.statusCode, 500);
+  assert.deepEqual(resFail.body, { error: 'notify failed' });
+
+  // success path
+  nextStatus = 200;
+  const resOk = createRes();
+  await handler({ body: { text: 'hi' } } as any, resOk as any);
+  assert.equal(resOk.statusCode, 200);
+  assert.deepEqual(resOk.body, { sent: true });
+
+  server.close();
+  console.log('Notification bot tests passed');
+})();

--- a/apps/notification-bot/index.ts
+++ b/apps/notification-bot/index.ts
@@ -5,7 +5,7 @@ import { callWithRetry } from '../../packages/shared/retry';
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   const { text } = req.body as { text: string };
   try {
-    await callWithRetry(
+    const resp = await callWithRetry(
       SLACK_WEBHOOK_URL,
       {
         method: 'POST',
@@ -15,6 +15,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       'notification-bot',
       'slack'
     );
+    if (!resp) throw new Error('slack request failed');
     res.status(200).json({ sent: true });
   } catch (err:any) {
     console.error(err);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "tsc -p tsconfig.json --noEmit && tsx apps/curriculum-editor/index.test.ts && tsx apps/qa-formatter/index.test.ts && tsx apps/dispatcher/index.test.ts && tsx apps/orchestrator/index.test.ts && tsx apps/performance-recorder/index.test.ts && tsx apps/data-aggregator/index.test.ts"
+    "test": "tsc -p tsconfig.json --noEmit && tsx apps/curriculum-editor/index.test.ts && tsx apps/qa-formatter/index.test.ts && tsx apps/dispatcher/index.test.ts && tsx apps/orchestrator/index.test.ts && tsx apps/performance-recorder/index.test.ts && tsx apps/data-aggregator/index.test.ts && tsx apps/notification-bot/index.test.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",


### PR DESCRIPTION
## Summary
- Throw an error when Slack webhook call via `callWithRetry` returns null
- Add notification-bot tests for success and failure scenarios
- Run notification-bot tests with the standard `npm test` script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5334470348330a69470a712a76608