### PR TITLE
test: verify append-only policies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.4.2",
+        "pg": "^8.11.5",
         "ts-node": "^10.9.1",
         "tsx": "^4.20.5",
         "typescript": "^5.2.2"
@@ -2136,6 +2137,103 @@
       "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "license": "MIT"
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -2152,6 +2250,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -2272,6 +2413,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/time-span": {
@@ -2512,6 +2663,16 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/yn": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "tsc -p tsconfig.json --noEmit && tsx apps/curriculum-editor/index.test.ts && tsx apps/qa-formatter/index.test.ts && tsx apps/lesson-picker/index.test.ts && tsx apps/dispatcher/index.test.ts && tsx apps/orchestrator/index.test.ts && tsx apps/performance-recorder/index.test.ts && tsx apps/data-aggregator/index.test.ts && tsx apps/notification-bot/index.test.ts"
+    "test": "tsc -p tsconfig.json --noEmit && tsx apps/curriculum-editor/index.test.ts && tsx apps/qa-formatter/index.test.ts && tsx apps/lesson-picker/index.test.ts && tsx apps/dispatcher/index.test.ts && tsx apps/orchestrator/index.test.ts && tsx apps/performance-recorder/index.test.ts && tsx apps/data-aggregator/index.test.ts && tsx apps/notification-bot/index.test.ts && tsx supabase/tests/immutability.test.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.0",
@@ -21,6 +21,7 @@
     "@types/node": "^20.4.2",
     "ts-node": "^10.9.1",
     "tsx": "^4.20.5",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "pg": "^8.11.5"
   }
 }

--- a/supabase/migrations/0012_append_only_policies.sql
+++ b/supabase/migrations/0012_append_only_policies.sql
@@ -1,0 +1,9 @@
+-- Deny updates and deletes on append-only tables beyond curricula
+create policy update_lessons_denied on lessons for update using (false) with check (false);
+create policy delete_lessons_denied on lessons for delete using (false);
+
+create policy update_performances_denied on performances for update using (false) with check (false);
+create policy delete_performances_denied on performances for delete using (false);
+
+create policy update_assignments_denied on assignments for update using (false) with check (false);
+create policy delete_assignments_denied on assignments for delete using (false);

--- a/supabase/tests/immutability.test.ts
+++ b/supabase/tests/immutability.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { Client } from 'pg';
+import { promises as fs } from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+(async () => {
+  // Ensure postgres cluster is running
+  try {
+    execSync('pg_ctlcluster 16 main start');
+  } catch {}
+
+  const admin = new Client({ user: 'postgres', password: 'postgres', host: 'localhost', port: 5432, database: 'postgres' });
+  await admin.connect();
+
+  // Reset schema
+  await admin.query('drop schema public cascade; create schema public; grant all on schema public to postgres; grant all on schema public to public;');
+
+  // Ensure required roles exist
+  await admin.query("drop role if exists anon; drop role if exists authenticated; drop role if exists service_role;");
+  await admin.query("create role anon login password 'anon';");
+  await admin.query('create role authenticated;');
+  await admin.query('create role service_role;');
+
+  // Run migrations
+  const migrationsDir = path.join(process.cwd(), 'supabase', 'migrations');
+  const files = (await fs.readdir(migrationsDir)).sort();
+  for (const file of files) {
+    const sql = await fs.readFile(path.join(migrationsDir, file), 'utf8');
+    await admin.query(sql);
+  }
+
+  // Seed required data
+  const studentId = '00000000-0000-0000-0000-000000000001';
+  await admin.query("insert into students(id, name, timezone) values ($1, 'Test', 'UTC')", [studentId]);
+
+  // Grant privileges to anon
+  await admin.query('grant usage on schema public to anon;');
+  await admin.query('grant select, insert, update, delete on all tables in schema public to anon;');
+  await admin.end();
+
+  const anon = new Client({ user: 'anon', password: 'anon', host: 'localhost', port: 5432, database: 'postgres' });
+  await anon.connect();
+
+  const lessonId = '00000000-0000-0000-0000-000000000101';
+  const performanceId = '00000000-0000-0000-0000-000000000201';
+  const assignmentId = '00000000-0000-0000-0000-000000000301';
+
+  // Insert initial records
+  await anon.query('insert into lessons(id, topic, difficulty) values ($1, $2, 1)', [lessonId, 'Topic']);
+  await anon.query("insert into curricula(version, student_id, curriculum) values (1, $1, '{}'::jsonb)", [studentId]);
+  await anon.query('insert into performances(id, student_id, lesson_id, score) values ($1, $2, $3, 0)', [performanceId, studentId, lessonId]);
+  await anon.query("insert into assignments(id, lesson_id, student_id, questions_json, generated_by) values ($1, $2, $3, '{}'::jsonb, 'gpt')", [assignmentId, lessonId, studentId]);
+  await anon.query("insert into curricula_drafts(student_id, version, curriculum) values ($1, 1, '{}'::jsonb)", [studentId]);
+
+  // Immutable tables should ignore updates and deletes
+  let res = await anon.query("update lessons set topic='New' where id=$1", [lessonId]);
+  assert.equal(res.rowCount, 0);
+  res = await anon.query('delete from lessons where id=$1', [lessonId]);
+  assert.equal(res.rowCount, 0);
+
+  res = await anon.query('update performances set score=1 where id=$1', [performanceId]);
+  assert.equal(res.rowCount, 0);
+  res = await anon.query('delete from performances where id=$1', [performanceId]);
+  assert.equal(res.rowCount, 0);
+
+  res = await anon.query("update assignments set generated_by='test' where id=$1", [assignmentId]);
+  assert.equal(res.rowCount, 0);
+  res = await anon.query('delete from assignments where id=$1', [assignmentId]);
+  assert.equal(res.rowCount, 0);
+
+  res = await anon.query("update curricula set curriculum='{}'::jsonb where student_id=$1 and version=1", [studentId]);
+  assert.equal(res.rowCount, 0);
+  res = await anon.query('delete from curricula where student_id=$1 and version=1', [studentId]);
+  assert.equal(res.rowCount, 0);
+
+  // Drafts remain mutable
+  await anon.query("update curricula_drafts set curriculum='{\"updated\":true}'::jsonb where student_id=$1 and version=1", [studentId]);
+  await anon.query('delete from curricula_drafts where student_id=$1 and version=1', [studentId]);
+
+  await anon.end();
+})();


### PR DESCRIPTION
## Summary
- add RLS policies to explicitly block updates and deletes on lessons, performances, and assignments
- test that immutable tables ignore modifications while curricula drafts remain editable

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54029266c8330b3b985f9fd362f7f