### PR TITLE
Add SuperfastSAT API URL config

### DIFF
--- a/apps/curriculum-editor/index.test.ts
+++ b/apps/curriculum-editor/index.test.ts
@@ -13,6 +13,7 @@ process.env.CURRICULUM_EDITOR_URL = 'http://example.com';
 process.env.QA_FORMATTER_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.SUPERFASTSAT_API_URL = 'http://example.com';
 
 (async () => {
   const { fetchLatestSummary } = await import('./index');

--- a/apps/data-aggregator/index.test.ts
+++ b/apps/data-aggregator/index.test.ts
@@ -13,6 +13,7 @@ process.env.CURRICULUM_EDITOR_URL = 'http://example.com';
 process.env.QA_FORMATTER_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.SUPERFASTSAT_API_URL = 'http://example.com';
 
 (async () => {
   const { aggregateStudentStats } = await import('./index');

--- a/apps/dispatcher/index.ts
+++ b/apps/dispatcher/index.ts
@@ -1,5 +1,6 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import { supabase } from '../../packages/shared/supabase';
+import { SUPERFASTSAT_API_URL } from '../../packages/shared/config';
 
 async function selectUnits(curriculum: any, minutes: number) {
   const units: any[] = [];
@@ -61,7 +62,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       }
     }
 
-    const response = await fetch(`${process.env.SUPERFASTSAT_API_URL}/units`, {
+    const response = await fetch(`${SUPERFASTSAT_API_URL}/units`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ units: selected.units }),

--- a/apps/lesson-picker/index.test.ts
+++ b/apps/lesson-picker/index.test.ts
@@ -13,6 +13,7 @@ process.env.CURRICULUM_EDITOR_URL = 'http://example.com';
 process.env.QA_FORMATTER_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.SUPERFASTSAT_API_URL = 'http://example.com';
 
 class MockRedis {
   async lrange(_key: string, _start: number, _end: number) {

--- a/apps/notification-bot/index.test.ts
+++ b/apps/notification-bot/index.test.ts
@@ -13,6 +13,7 @@ process.env.CURRICULUM_EDITOR_URL = 'http://example.com';
 process.env.QA_FORMATTER_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.SUPERFASTSAT_API_URL = 'http://example.com';
 
 (async () => {
   let nextStatus = 500;

--- a/apps/orchestrator/index.test.ts
+++ b/apps/orchestrator/index.test.ts
@@ -9,6 +9,7 @@ process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
 process.env.UPSTASH_REDIS_REST_URL = 'http://localhost';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
 process.env.ORCHESTRATOR_SECRET = 'secret';
+process.env.SUPERFASTSAT_API_URL = 'http://localhost';
 
 (async () => {
   // start mock server

--- a/apps/performance-recorder/index.test.ts
+++ b/apps/performance-recorder/index.test.ts
@@ -13,6 +13,7 @@ process.env.CURRICULUM_EDITOR_URL = 'http://example.com';
 process.env.QA_FORMATTER_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.SUPERFASTSAT_API_URL = 'http://example.com';
 
 class MockRedis {
   public lastExpire: [string, number] | null = null;

--- a/apps/qa-formatter/index.test.ts
+++ b/apps/qa-formatter/index.test.ts
@@ -13,6 +13,7 @@ process.env.CURRICULUM_EDITOR_URL = 'http://example.com';
 process.env.QA_FORMATTER_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.SUPERFASTSAT_API_URL = 'http://example.com';
 
 (async () => {
   // Stub network and database interactions used by notify

--- a/packages/shared/config.ts
+++ b/packages/shared/config.ts
@@ -11,6 +11,7 @@ const envSchema = z.object({
   DATA_AGGREGATOR_URL: z.string().url(),
   CURRICULUM_EDITOR_URL: z.string().url(),
   QA_FORMATTER_URL: z.string().url(),
+  SUPERFASTSAT_API_URL: z.string().url(),
   UPSTASH_REDIS_REST_URL: z.string().url(),
   UPSTASH_REDIS_REST_TOKEN: z.string().min(1),
 });
@@ -32,6 +33,7 @@ export const {
   DATA_AGGREGATOR_URL,
   CURRICULUM_EDITOR_URL,
   QA_FORMATTER_URL,
+  SUPERFASTSAT_API_URL,
   UPSTASH_REDIS_REST_URL,
   UPSTASH_REDIS_REST_TOKEN,
 } = env.data;

--- a/packages/shared/memory.test.ts
+++ b/packages/shared/memory.test.ts
@@ -13,6 +13,7 @@ process.env.CURRICULUM_EDITOR_URL = 'http://example.com';
 process.env.QA_FORMATTER_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_URL = 'http://example.com';
 process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
+process.env.SUPERFASTSAT_API_URL = 'http://example.com';
 
 class MockRedis {
   public lastSet: [string, string, any] | null = null;


### PR DESCRIPTION
## Summary
- add `SUPERFASTSAT_API_URL` to shared config and export
- use validated URL in dispatcher instead of `process.env`
- set new env var in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5456ef6548330b5dcc164fdf97f6b