### PR TITLE
Count only sent dispatches in data aggregator

### DIFF
--- a/apps/data-aggregator/index.test.ts
+++ b/apps/data-aggregator/index.test.ts
@@ -23,7 +23,6 @@ process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
   const dispatches = [
     { student_id: 's1', status: 'sent' },
     { student_id: 's1', status: 'failed' },
-    { student_id: 's2', status: 'sent' },
     { student_id: 's2', status: 'failed' },
   ];
 
@@ -37,6 +36,6 @@ process.env.UPSTASH_REDIS_REST_TOKEN = 'token';
   const s1 = students.find((s) => s.student_id === 's1');
   const s2 = students.find((s) => s.student_id === 's2');
   assert.equal(s1?.completion_rate, 1);
-  assert.equal(s2?.completion_rate, 0);
+  assert.equal(s2, undefined);
   console.log('Accurate completion rates with mixed dispatch statuses');
 })();

--- a/apps/data-aggregator/index.ts
+++ b/apps/data-aggregator/index.ts
@@ -13,7 +13,7 @@ interface Performance {
 
 interface Dispatch {
   student_id: string;
-  status?: string;
+  status: string;
 }
 
 export async function aggregateStudentStats(
@@ -37,7 +37,7 @@ export async function aggregateStudentStats(
   });
 
   dispatches
-    .filter((d) => !d.status || d.status === 'sent')
+    .filter((d) => d.status === 'sent')
     .forEach((d) => {
       if (!studentMap[d.student_id]) studentMap[d.student_id] = { scores: [], confidences: [], points: [] };
       assignments[d.student_id] = (assignments[d.student_id] || 0) + 1;
@@ -80,8 +80,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
     const { data: dispatches } = await supabase
       .from('dispatch_log')
-      .select('student_id')
-      .eq('status', 'sent')
+      .select('student_id, status')
       .gte('sent_at', since);
 
     const students = await aggregateStudentStats(performances ?? [], dispatches ?? [], safeTimestamp);


### PR DESCRIPTION
## Summary
- Include dispatch status when querying `dispatch_log`
- Compute assignments only for dispatches with status `sent`
- Adjust stats tests to ensure failed dispatches are ignored

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b54583ad908330a15d4e1cf7378043