### PR TITLE
docs: clarify Data Aggregator dispatch_log dependency

### DIFF
--- a/docs/mas-brief.md
+++ b/docs/mas-brief.md
@@ -70,7 +70,7 @@ run completes.
 | Lesson Picker | `students`, recent `performances`, `curricula`, `lessons` | `dispatch_log` |
 | Dispatcher | `students`, `lessons`, `dispatch_log` | `dispatch_log(status)` |
 | Performance Recorder | – | `performances` |
-| Data Aggregator | `performances`, charts 📊 | Supabase Storage `performance_summary.json` |
+| Data Aggregator | `performances`, `dispatch_log`, charts 📊 | Supabase Storage `performance_summary.json` |
 | Curriculum Editor | `performance_summary`, `lessons` | `curricula_drafts` |
 | QA & Formatter | `curricula_drafts` | `curricula`, `students.current_curriculum_version` |
 | Notification Bot | Event stream | Slack |


### PR DESCRIPTION
## Summary
- mention `dispatch_log` in Data Aggregator's READS documentation

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b552bb5e0083309dea93544ea47db5