### PR TITLE
Skip mastered question types

### DIFF
--- a/apps/orchestrator/index.test.ts
+++ b/apps/orchestrator/index.test.ts
@@ -17,6 +17,7 @@ process.env.SCHEDULER_SECRET = 'sched-secret';
   // start mock server
   let dispatcherBody: any = null;
   let lessonPickerBody: any = null;
+  let curriculumBody: any = null;
   let lessonPickerResp: any = { minutes: 5, next_lesson_id: 'l42' };
   const qaBodies: any[] = [];
   let qaStatus = 200;
@@ -30,6 +31,10 @@ process.env.SCHEDULER_SECRET = 'sched-secret';
         res.end(JSON.stringify(lessonPickerResp));
       } else if (req.url === '/dispatcher') {
         dispatcherBody = body ? JSON.parse(body) : null;
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end('{}');
+      } else if (req.url === '/mod') {
+        curriculumBody = body ? JSON.parse(body) : null;
         res.writeHead(200, { 'Content-Type': 'application/json' });
         res.end('{}');
       } else if (req.url === '/qa') {
@@ -148,6 +153,15 @@ process.env.SCHEDULER_SECRET = 'sched-secret';
   assert.deepEqual(mockRedis.store, {});
   assert.deepEqual(dispatcherBody.units, [{ id: 'u1' }]);
   assert.equal(dispatcherBody.minutes, undefined);
+
+  // lesson picker requests new curriculum
+  dispatcherBody = null;
+  curriculumBody = null;
+  lessonPickerResp = { action: 'request_new_curriculum' };
+  await handler(req, res);
+  assert.equal(status, 200);
+  assert.equal(curriculumBody.student_id, 1);
+  assert.equal(dispatcherBody, null);
 
   // failure during orchestration should also clean drafts
   dispatcherBody = null;

--- a/apps/orchestrator/index.ts
+++ b/apps/orchestrator/index.ts
@@ -105,6 +105,22 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
           if (lastResp) {
             try {
               const ctx = await lastResp.json();
+              if (ctx?.action === 'request_new_curriculum') {
+                await callWithRetry(
+                  CURRICULUM_EDITOR_URL,
+                  {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ student_id: student.id })
+                  },
+                  runType,
+                  `curriculum-editor:${student.id}`,
+                  3,
+                  'orchestrator_log'
+                );
+                lastResp = null;
+                break;
+              }
               const key = `${step.label}:${student.id}`;
               await writeDraft(key, ctx);
               usedDraftKeys.add(key);


### PR DESCRIPTION
## Summary
- Consult `student_progress` to remove mastered question types and request new curriculum when none remain
- Handle `request_new_curriculum` signal in orchestrator by triggering curriculum editor
- Cover mastery-aware selection and curriculum requests in tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b801bf3d58833086c19d0e3b8ac825